### PR TITLE
use TESTSPACE_TOKEN in push env

### DIFF
--- a/tests/test_testspace.py
+++ b/tests/test_testspace.py
@@ -19,9 +19,6 @@ def test_http():
     space = "master"
     protocol = "http"
 
-    client_url = "{}://{}".format(protocol, url)
-    api_url = "{}://{}/api".format(protocol, url)
-
     testspace_url = "{}://{}".format(protocol, url)
     testspace = ts.Testspace(token, testspace_url, project, space)
     assert testspace.url == "{}://{}".format(protocol, url)

--- a/tests/test_testspace.py
+++ b/tests/test_testspace.py
@@ -1,34 +1,15 @@
 from testspace import testspace as ts
 
 
-def test_url_token():
+def test_url():
     token = "abcxyzfortesting"
     url = "abccorp.testspace.com"
     project = "abccorp:application"
     space = "master"
     protocol = "https"
 
-    client_url = "{}:@{}".format(token, url)
-    api_url = "{}://{}/api".format(protocol, url)
-
     testspace = ts.Testspace(token, url, project, space)
-    assert testspace.client_url == client_url
-    assert testspace.api_url == api_url
-
-
-def test_url_password():
-    token = "absmith:passfortesting"
-    url = "abccorp.testspace.com"
-    project = "abccorp:application"
-    space = "master"
-    protocol = "https"
-
-    client_url = "{}@{}".format(token, url)
-    api_url = "{}://{}/api".format(protocol, url)
-
-    testspace = ts.Testspace(token, url, project, space)
-    assert testspace.client_url == client_url
-    assert testspace.api_url == api_url
+    assert testspace.url == "{}://{}".format(protocol, url)
 
 
 def test_http():
@@ -38,10 +19,9 @@ def test_http():
     space = "master"
     protocol = "http"
 
-    client_url = "{}://{}:@{}".format(protocol, token, url)
+    client_url = "{}://{}".format(protocol, url)
     api_url = "{}://{}/api".format(protocol, url)
 
     testspace_url = "{}://{}".format(protocol, url)
     testspace = ts.Testspace(token, testspace_url, project, space)
-    assert testspace.client_url == client_url
-    assert testspace.api_url == api_url
+    assert testspace.url == "{}://{}".format(protocol, url)

--- a/tests/test_testspace_api.py
+++ b/tests/test_testspace_api.py
@@ -31,10 +31,7 @@ def test_get_api_endpoints(load_json, testspace_api, requests_mock):
 
 @pytest.mark.parametrize("load_json", ["api_endpoints.json"], indirect=True)
 def test_get_api_endpoints_url_https(load_json, testspace_api, requests_mock):
-    url = "{}://{}".format("https", testspace_api.url)
-    testspace_url = "/".join([url, "api"])
-
-    testspace_api = ts.Testspace(testspace_api.token, url)
+    testspace_url = "/".join([testspace_api.url, "api"])
 
     requests_mock.get(testspace_url, json=load_json)
     response_json = testspace_api.get_api_endpoints()
@@ -68,8 +65,7 @@ def test_get_projects(load_json, testspace_api, requests_mock):
 
 @pytest.mark.parametrize("load_json", ["projects.json"], indirect=True)
 def test_get_projects_paginated(load_json, testspace_api, requests_mock):
-    url = testspace_api.url
-    testspace_url = "https://{}/api/projects".format(url)
+    testspace_url = "{}/api/projects".format(testspace_api.url)
 
     links_string_first = '<{}?page={}>; rel="{}"'.format(testspace_url, 1, "first")
     links_string_next = '<{}?page={}>; rel="{}"'.format(testspace_url, 2, "next")

--- a/tests/test_testspace_client.py
+++ b/tests/test_testspace_client.py
@@ -33,8 +33,7 @@ def test_push(mocker, testspace_client):
         message=message,
     )
 
-    url = "{}@{}/{}/{}?{}#{}".format(
-        testspace_client.token,
+    url = "{}/{}/{}?{}#{}".format(
         testspace_client.url,
         testspace_client.project,
         testspace_client.space,
@@ -50,7 +49,7 @@ def test_push(mocker, testspace_client):
 
     mock_call_args = mock.call_args_list[0][0]
     returned_push_command = mock_call_args[0]
-    assert expected_push_command == returned_push_command
+    assert " ".join(expected_push_command) == returned_push_command
 
 
 def test_push_project_none():

--- a/tests/test_testspace_client.py
+++ b/tests/test_testspace_client.py
@@ -49,7 +49,7 @@ def test_push(mocker, testspace_client):
 
     mock_call_args = mock.call_args_list[0][0]
     returned_push_command = mock_call_args[0]
-    assert " ".join(expected_push_command) == returned_push_command
+    assert expected_push_command == returned_push_command
 
 
 def test_push_project_none():

--- a/testspace/testspace.py
+++ b/testspace/testspace.py
@@ -67,7 +67,7 @@ class Testspace:
         subprocess.run(
             command_args_list,
             check=True,
-            env=dict(os.environ, TESTSPACE_TOKEN=self.token)
+            env=dict(os.environ, TESTSPACE_TOKEN=self.token),
         )
 
     def get_api_endpoints(self):

--- a/testspace/testspace.py
+++ b/testspace/testspace.py
@@ -65,8 +65,7 @@ class Testspace:
             command_args_list.append("--message={}".format(message))
 
         subprocess.run(
-            " ".join(command_args_list),
-            shell=True,
+            command_args_list,
             check=True,
             env=dict(os.environ, TESTSPACE_TOKEN=self.token)
         )


### PR DESCRIPTION
#2 

* Merge client and api token into one. Token is added in run or request and no longer needed in url