### PR TITLE
Limit page nexts

### DIFF
--- a/tests/test_testspace_api.py
+++ b/tests/test_testspace_api.py
@@ -90,7 +90,7 @@ def test_get_projects_paginated(load_json, testspace_api, requests_mock):
         json=load_json[:1],
         headers={"link": ", ".join([links_string_first, links_string_last])},
     )
-    response_json = testspace_api.get_projects()
+    response_json = testspace_api.get_projects(limit=None)
 
     project_names = [project["name"] for project in response_json]
     assert testspace_api.project in project_names
@@ -98,7 +98,28 @@ def test_get_projects_paginated(load_json, testspace_api, requests_mock):
 
 @pytest.mark.parametrize("load_json", ["projects.json"], indirect=True)
 def test_get_projects_paginated_limited(load_json, testspace_api, requests_mock):
-    requests_mock.get("/api/projects", json=load_json)
+    url = testspace_api.url
+    testspace_url = "https://{}/api/projects".format(url)
+
+    links_string_first = '<{}?page={}>; rel="{}"'.format(testspace_url, 1, "first")
+    links_string_next = '<{}?page={}>; rel="{}"'.format(testspace_url, 2, "next")
+    links_string_last = '<{}?page={}>; rel="{}"'.format(testspace_url, 2, "last")
+
+    requests_mock.get(
+        "/api/projects",
+        json=load_json[1:],
+        headers={
+            "link": ", ".join(
+                [links_string_first, links_string_next, links_string_last]
+            )
+        },
+        complete_qs=True,
+    )
+    requests_mock.get(
+        "/api/projects?page=2",
+        json=load_json[:1],
+        headers={"link": ", ".join([links_string_first, links_string_last])},
+    )
     num_projects = 1
     response_json = testspace_api.get_projects(limit=num_projects)
 

--- a/tests/test_testspace_api.py
+++ b/tests/test_testspace_api.py
@@ -97,6 +97,15 @@ def test_get_projects_paginated(load_json, testspace_api, requests_mock):
 
 
 @pytest.mark.parametrize("load_json", ["projects.json"], indirect=True)
+def test_get_projects_paginated_limited(load_json, testspace_api, requests_mock):
+    requests_mock.get("/api/projects", json=load_json)
+    num_projects = 1
+    response_json = testspace_api.get_projects(limit=num_projects)
+
+    assert len(response_json) == num_projects
+
+
+@pytest.mark.parametrize("load_json", ["projects.json"], indirect=True)
 def test_get_project_name(load_json, testspace_api, requests_mock):
     project = testspace_api.project
     project_json = [item for item in load_json if item["name"] == project][0]

--- a/testspace/testspace.py
+++ b/testspace/testspace.py
@@ -177,12 +177,12 @@ class Testspace:
         if type(limit) is not int or limit <= 0:
             raise ValueError
         response = self.get_request(path)
-        if len(response.links) == 0:
+        response_json = response.json()
+        if type(response_json) is not list:
             return response.json()
         else:
             next_url = response.links.get("next", None)
-            response_json = response.json()
-            while next_url is not None:
+            while next_url is not None and len(response_json) < limit:
                 response = self.get_request(next_url.get("url"))
                 next_url = response.links.get("next", None)
                 response_json.extend(response.json())

--- a/testspace/testspace.py
+++ b/testspace/testspace.py
@@ -174,19 +174,22 @@ class Testspace:
         return response
 
     def get_request_json(self, path=None, limit=30):
-        if type(limit) is not int or limit <= 0:
+        if limit is None:
+            pass
+        elif type(limit) is not int or limit <= 0:
             raise ValueError
         response = self.get_request(path)
         response_json = response.json()
-        if type(response_json) is not list:
-            return response.json()
-        else:
+        if type(response_json) is list:
             next_url = response.links.get("next", None)
-            while next_url is not None and len(response_json) < limit:
+            while next_url is not None:
                 response = self.get_request(next_url.get("url"))
                 next_url = response.links.get("next", None)
                 response_json.extend(response.json())
-        return response_json[:limit]
+                if limit is not None and len(response_json) >= limit:
+                    break
+            response_json = response_json[:limit]
+        return response_json
 
     def post_request(self, payload, path=None):
         response = self._api_request("POST", path=path, payload=payload)


### PR DESCRIPTION
Fixes the following issues.
* Current implementation gets all pages and then slices list based on limit size.
* Allows no limit to be set by `None` instead of just guessing at a large number. 