### PR TITLE
move limit check

### DIFF
--- a/tests/test_testspace_api.py
+++ b/tests/test_testspace_api.py
@@ -89,6 +89,7 @@ def test_get_projects_paginated(load_json, testspace_api, requests_mock):
     response_json = testspace_api.get_projects(limit=None)
 
     project_names = [project["name"] for project in response_json]
+    assert len(response_json) == len(load_json)
     assert testspace_api.project in project_names
 
 
@@ -103,7 +104,7 @@ def test_get_projects_paginated_limited(load_json, testspace_api, requests_mock)
 
     requests_mock.get(
         "/api/projects",
-        json=load_json[1:],
+        json=load_json,
         headers={
             "link": ", ".join(
                 [links_string_first, links_string_next, links_string_last]
@@ -111,11 +112,7 @@ def test_get_projects_paginated_limited(load_json, testspace_api, requests_mock)
         },
         complete_qs=True,
     )
-    requests_mock.get(
-        "/api/projects?page=2",
-        json=load_json[:1],
-        headers={"link": ", ".join([links_string_first, links_string_last])},
-    )
+
     num_projects = 1
     response_json = testspace_api.get_projects(limit=num_projects)
 

--- a/testspace/testspace.py
+++ b/testspace/testspace.py
@@ -183,11 +183,11 @@ class Testspace:
         if type(response_json) is list:
             next_url = response.links.get("next", None)
             while next_url is not None:
+                if limit is not None and len(response_json) >= limit:
+                    break
                 response = self.get_request(next_url.get("url"))
                 next_url = response.links.get("next", None)
                 response_json.extend(response.json())
-                if limit is not None and len(response_json) >= limit:
-                    break
             response_json = response_json[:limit]
         return response_json
 


### PR DESCRIPTION
* Move limit check to prevent second page being called when limit had already been reached.
* Update test case for page limit. Will now fail if second page called as there is no mock address for it.